### PR TITLE
Move coordinates in HTTP path to request body

### DIFF
--- a/api-calls/ghost/post_new_ghost.sh
+++ b/api-calls/ghost/post_new_ghost.sh
@@ -1,8 +1,12 @@
 #!/bin/sh
 
-curl \
-  --include \
-  --request POST  \
-  --header "Content-Type: application/json" \
-  --data '{"latitude":1.23,"longitude":12.3}' \
-  http://localhost:8080/ghost
+if [ $# -ge 2 ] ; then
+    curl \
+      --include \
+      --request POST  \
+      --header "Content-Type: application/json" \
+      --data '{"latitude":'$1',"longitude":'$2'}' \
+      http://localhost:8080/ghost
+else
+    echo "Usage: ./post_new_ghost.sh latitude longitude"
+fi

--- a/api-calls/ghost/post_new_ghost.sh
+++ b/api-calls/ghost/post_new_ghost.sh
@@ -1,9 +1,8 @@
 #!/bin/sh
 
-if [ $# -ge 2 ] ; then
-    curl \
-      --request POST --include \
-      http://localhost:8080/ghost/"$1"/"$2"
-else
-    echo "Usage: ./post_new_ghost.sh latitude longitude"
-fi
+curl \
+  --include \
+  --request POST  \
+  --header "Content-Type: application/json" \
+  --data '{"latitude":1.23,"longitude":12.3}' \
+  http://localhost:8080/ghost

--- a/api-calls/ghost/put_ghost_location_by_id.sh
+++ b/api-calls/ghost/put_ghost_location_by_id.sh
@@ -2,8 +2,11 @@
 
 if [ $# -ge 3 ] ; then
     curl \
-      --request PUT --include \
-      http://localhost:8080/ghost/"$1"/location/"$2"/"$3"
+      --include \
+      --request PUT  \
+      --header "Content-Type: application/json" \
+      --data '{"latitude":'$2',"longitude":'$3'}' \
+      http://localhost:8080/ghost/"$1"/location
 else
     echo "Usage: ./put_ghost_location_by_id.sh id latitude longitude"
 fi

--- a/api-calls/pacman/post_new_pacman.sh
+++ b/api-calls/pacman/post_new_pacman.sh
@@ -2,8 +2,11 @@
 
 if [ $# -ge 2 ] ; then
     curl \
-      --request POST --include \
-      http://localhost:8080/pacman/"$1"/"$2"
+      --include \
+      --request POST \
+      --header "Content-Type: application/json" \
+      --data '{"latitude":'$1',"longitude":'$2'}' \
+      http://localhost:8080/pacman
 else
     echo "Usage: ./post_new_pacman.sh latitude longitude"
 fi

--- a/api-calls/pacman/put_pacman_location.sh
+++ b/api-calls/pacman/put_pacman_location.sh
@@ -2,8 +2,11 @@
 
 if [ $# -ge 2 ] ; then
     curl \
-      --request PUT --include \
-      http://localhost:8080/pacman/location/"$1"/"$2"
+      --include \
+      --request PUT \
+      --header "Content-Type: application/json" \
+      --data '{"latitude":'$1',"longitude":'$2'}' \
+      http://localhost:8080/pacman/location
 else
     echo "Usage: ./put_pacman_location.sh latitude longitude"
 fi

--- a/src/main/java/com/pm/server/controller/GhostController.java
+++ b/src/main/java/com/pm/server/controller/GhostController.java
@@ -227,7 +227,7 @@ public class GhostController {
 	@ResponseStatus(value = HttpStatus.OK)
 	public void setGhostLocationById(
 			@PathVariable Integer id,
-			@RequestBody Coordinate location)
+			@RequestBody CoordinateImpl location)
 			throws BadRequestException, NotFoundException {
 
 		log.debug("Mapped PUT /ghost/{}/location", id);

--- a/src/main/java/com/pm/server/controller/GhostController.java
+++ b/src/main/java/com/pm/server/controller/GhostController.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -40,22 +41,27 @@ public class GhostController {
 			LogManager.getLogger(GhostController.class.getName());
 
 	@RequestMapping(
-			value = "/{latitude}/{longitude}",
+			value = "",
 			method=RequestMethod.POST,
 			produces={ "application/json" }
 	)
 	@ResponseStatus(value = HttpStatus.OK)
 	public IdResponse createGhost(
-			@PathVariable double latitude,
-			@PathVariable double longitude,
-			HttpServletResponse response) throws ConflictException {
+			@RequestBody(required = false) CoordinateImpl location)
+			throws ConflictException, BadRequestException {
 
-		log.debug("Mapped POST /ghost/{}/{}", latitude, longitude);
+		log.debug("Mapped POST /ghost");
+		log.debug("Request body: {}", JsonUtils.objectToJson(location));
 
-		log.debug("Creating Ghost at ({}, {}).", latitude, longitude);
+		validateRequestBodyWithLocation(location);
+
+		log.debug("Creating Ghost at ({}, {}).",
+				location.getLatitude(),
+				location.getLongitude()
+		);
 
 		Ghost ghost = new GhostImpl();
-		ghost.setLocation(new CoordinateImpl(latitude, longitude));
+		ghost.setLocation(location);
 
 		Random random = new Random();
 

--- a/src/main/java/com/pm/server/controller/GhostController.java
+++ b/src/main/java/com/pm/server/controller/GhostController.java
@@ -221,20 +221,19 @@ public class GhostController {
 	}
 
 	@RequestMapping(
-			value="/{id}/location/{latitude}/{longitude}",
+			value="/{id}/location",
 			method=RequestMethod.PUT
 	)
 	@ResponseStatus(value = HttpStatus.OK)
 	public void setGhostLocationById(
 			@PathVariable Integer id,
-			@PathVariable double latitude,
-			@PathVariable double longitude,
-			HttpServletResponse response)
-			throws NotFoundException {
+			@RequestBody Coordinate location)
+			throws BadRequestException, NotFoundException {
 
-		log.debug(
-				"Mapped PUT /ghost/{}/location/{}/{}",
-				id, latitude, longitude);
+		log.debug("Mapped PUT /ghost/{}/location", id);
+		log.debug("Request body: {}", JsonUtils.objectToJson(location));
+
+		validateRequestBodyWithLocation(location);
 
 		Ghost ghost = ghostRepository.getPlayerById(id);
 		if(ghost == null) {
@@ -248,12 +247,9 @@ public class GhostController {
 
 		log.debug(
 				"Setting ghost with id {} to ({}, {})",
-				id, latitude, longitude
+				id, location.getLatitude(), location.getLongitude()
 		);
-		ghostRepository.setPlayerLocationById(
-				id,
-				new CoordinateImpl(latitude, longitude)
-		);
+		ghostRepository.setPlayerLocationById(id, location);
 	}
 
 	private static void validateRequestBodyWithLocation(Coordinate location)

--- a/src/main/java/com/pm/server/controller/GhostController.java
+++ b/src/main/java/com/pm/server/controller/GhostController.java
@@ -16,7 +16,9 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.pm.server.datatype.Coordinate;
 import com.pm.server.datatype.CoordinateImpl;
+import com.pm.server.exceptionhttp.BadRequestException;
 import com.pm.server.exceptionhttp.ConflictException;
 import com.pm.server.exceptionhttp.InternalServerErrorException;
 import com.pm.server.exceptionhttp.NotFoundException;
@@ -246,6 +248,33 @@ public class GhostController {
 				id,
 				new CoordinateImpl(latitude, longitude)
 		);
+	}
+
+	private static void validateRequestBodyWithLocation(Coordinate location)
+			throws BadRequestException {
+
+		String errorMessage = null;
+
+		if(location == null) {
+			errorMessage = "Request body requires latitude and longitude.";
+		}
+		else if(
+				location.getLatitude() == null &&
+				location.getLongitude() == null) {
+			errorMessage = "Request body requires latitude and longitude.";
+		}
+		else if(location.getLatitude() == null) {
+			errorMessage = "Request body requires latitude.";
+		}
+		else if(location.getLongitude() == null) {
+			errorMessage = "Request body requires longitude.";
+		}
+
+		if(errorMessage != null) {
+			log.warn(errorMessage);
+			throw new BadRequestException(errorMessage);
+		}
+
 	}
 
 }

--- a/src/main/java/com/pm/server/controller/PacmanController.java
+++ b/src/main/java/com/pm/server/controller/PacmanController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.pm.server.datatype.Coordinate;
 import com.pm.server.datatype.CoordinateImpl;
+import com.pm.server.exceptionhttp.BadRequestException;
 import com.pm.server.exceptionhttp.ConflictException;
 import com.pm.server.exceptionhttp.InternalServerErrorException;
 import com.pm.server.exceptionhttp.NotFoundException;
@@ -143,6 +144,33 @@ public class PacmanController {
 		}
 
 		pacmanRepository.clearPlayers();
+	}
+
+	private static void validateRequestBodyWithLocation(Coordinate location)
+			throws BadRequestException {
+
+		String errorMessage = null;
+
+		if(location == null) {
+			errorMessage = "Request body requires latitude and longitude.";
+		}
+		else if(
+				location.getLatitude() == null &&
+				location.getLongitude() == null) {
+			errorMessage = "Request body requires latitude and longitude.";
+		}
+		else if(location.getLatitude() == null) {
+			errorMessage = "Request body requires latitude.";
+		}
+		else if(location.getLongitude() == null) {
+			errorMessage = "Request body requires longitude.";
+		}
+
+		if(errorMessage != null) {
+			log.warn(errorMessage);
+			throw new BadRequestException(errorMessage);
+		}
+
 	}
 
 }

--- a/src/main/java/com/pm/server/datatype/Coordinate.java
+++ b/src/main/java/com/pm/server/datatype/Coordinate.java
@@ -2,12 +2,12 @@ package com.pm.server.datatype;
 
 public interface Coordinate {
 
-	void setLatitude(double latitude);
+	void setLatitude(Double latitude);
 
-	double getLatitude();
+	Double getLatitude();
 
-	void setLongitude(double longitude);
+	void setLongitude(Double longitude);
 
-	double getLongitude();
+	Double getLongitude();
 
 }

--- a/src/main/java/com/pm/server/datatype/CoordinateImpl.java
+++ b/src/main/java/com/pm/server/datatype/CoordinateImpl.java
@@ -5,13 +5,19 @@ import org.apache.logging.log4j.Logger;
 
 public class CoordinateImpl implements Coordinate {
 
-	private double latitude;
-	private double longitude;
+	private Double latitude;
+	private Double longitude;
 
 	private final static Logger log =
 			LogManager.getLogger(CoordinateImpl.class.getName());
 
-	public CoordinateImpl(double latitude, double longitude) {
+	public CoordinateImpl() {
+		log.trace(
+				"Creating coordinate with null latitude and longitude."
+		);
+	}
+
+	public CoordinateImpl(Double latitude, Double longitude) {
 
 		log.trace(
 				"Creating coordinate with latitude {} and longitude {}",
@@ -22,25 +28,25 @@ public class CoordinateImpl implements Coordinate {
 		this.longitude = longitude;
 	}
 
-	public void setLatitude(double latitude) {
+	public void setLatitude(Double latitude) {
 
 		log.trace("Setting latitude to {}", latitude);
 
 		this.latitude = latitude;
 	}
 
-	public double getLatitude() {
+	public Double getLatitude() {
 		return latitude;
 	}
 
-	public void setLongitude(double longitude) {
+	public void setLongitude(Double longitude) {
 
 		log.trace("Setting longitude to {}", longitude);
 
 		this.longitude = longitude;
 	}
 
-	public double getLongitude() {
+	public Double getLongitude() {
 		return longitude;
 	}
 


### PR DESCRIPTION
This addresses issue #30.

This requires a change to the API; the Pacman and Ghost createPlayer and setPlayerLocation API endpoints no longer require the Player coordinates to be in the request path, and they are now required in the request body.

When this merge request is approved, I will update the API documentation accordingly.