### PR TITLE
Remove ID from API retrieval of Ghost Location

### DIFF
--- a/src/main/java/com/pm/server/controller/GhostController.java
+++ b/src/main/java/com/pm/server/controller/GhostController.java
@@ -27,6 +27,7 @@ import com.pm.server.player.Ghost;
 import com.pm.server.player.GhostImpl;
 import com.pm.server.repository.GhostRepository;
 import com.pm.server.response.IdResponse;
+import com.pm.server.response.LocationResponse;
 import com.pm.server.response.PlayerResponse;
 import com.pm.server.utils.JsonUtils;
 
@@ -153,7 +154,7 @@ public class GhostController {
 			produces={ "application/json" }
 	)
 	@ResponseStatus(value = HttpStatus.OK)
-	public PlayerResponse getGhostLocationById(
+	public LocationResponse getGhostLocationById(
 			@PathVariable Integer id,
 			HttpServletResponse response)
 			throws NotFoundException {
@@ -170,16 +171,16 @@ public class GhostController {
 			throw new NotFoundException(errorMessage);
 		}
 
-		PlayerResponse ghostResponse = new PlayerResponse();
-		ghostResponse.setId(ghost.getId());
-		ghostResponse.setLocation(ghost.getLocation());
+		LocationResponse locationResponse = new LocationResponse();
+		locationResponse.setLatitude(ghost.getLocation().getLatitude());
+		locationResponse.setLongitude(ghost.getLocation().getLongitude());
 
-		String objectString = JsonUtils.objectToJson(ghostResponse);
+		String objectString = JsonUtils.objectToJson(locationResponse);
 		if(objectString != null) {
-			log.debug("Returning ghostResponse: {}", objectString);
+			log.debug("Returning locationResponse: {}", objectString);
 		}
 
-		return ghostResponse;
+		return locationResponse;
 	}
 
 	@RequestMapping(

--- a/src/test/java/com/pm/server/controller/GhostControllerTest.java
+++ b/src/test/java/com/pm/server/controller/GhostControllerTest.java
@@ -241,10 +241,10 @@ public class GhostControllerTest extends ControllerTestTemplate {
 
 		// Then
 				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.location.latitude")
+				.andExpect(jsonPath("$.latitude")
 						.value(location.getLatitude())
 				)
-				.andExpect(jsonPath("$.location.longitude")
+				.andExpect(jsonPath("$.longitude")
 						.value(location.getLongitude())
 				);
 
@@ -500,9 +500,9 @@ public class GhostControllerTest extends ControllerTestTemplate {
 
 		assertNotNull(jsonContent);
 
-		Double latitude = JsonPath.read(jsonContent, "$.location.latitude");
+		Double latitude = JsonPath.read(jsonContent, "$.latitude");
 		assertNotNull(latitude);
-		Double longitude = JsonPath.read(jsonContent, "$.location.longitude");
+		Double longitude = JsonPath.read(jsonContent, "$.longitude");
 		assertNotNull(longitude);
 
 		return new CoordinateImpl(latitude, longitude);


### PR DESCRIPTION
This addresses issue #37.

Since the ghost's ID is required to request the ghost's location, it is redundant to return the ID. 

The JSON body has been modified from this:

```
{
	"id" : 12345,
	"location" : {
		"latitude" : 123.321,
		"longitude" : 321.123
	}
}
```

to this:
```
{
    "latitude" : 123.321,
    "longitude" : 321.123
}
```

I will update the API documentation when this merge is completed.

---

@CtrlShiftGo Requesting your approval of this API change.